### PR TITLE
fix: update webots launch commands for consistency with gazebo

### DIFF
--- a/scripts/benchmark_simulator.py
+++ b/scripts/benchmark_simulator.py
@@ -58,11 +58,11 @@ LAUNCH_CONFIGS = {
     },
     "webots": {
         "LAUNCH_SIMULATOR_CMD": [
-            "ros2", "launch", "webots_robotnik", "world_launch.py"
+            "ros2", "launch", "robotnik_webots", "spawn_world.launch.py"
         ],
         "LAUNCH_ROBOT_CMD": [
-            "ros2", "launch", "webots_robotnik", "robot_launch_alfa.py",
-            "robot:=rbwatcher", "namespace:=robot", "x:=2.0", "y:=2.0", "z:=0.0"
+            "ros2", "launch", "robotnik_webots", "spawn_robot.launch.py",
+            "robot:=rbwatcher", "robot_id:=robot", "x:=2.0", "y:=2.0", "z:=0.0"
         ],
         "NODES_TO_KILL": ["rviz2", "robot_state_publisher", "webots", "Ros2Supervisor", "static_transform_publisher"]
     },


### PR DESCRIPTION
This pull request updates the simulator launch commands for the Webots environment in the `scripts/benchmark_simulator.py` script. The changes primarily switch to new launch files and adjust some command-line arguments to align with updated naming conventions.

**Simulator launch command updates:**

* Changed the Webots simulator launch command to use the `robotnik_webots` package and the new `spawn_world.launch.py` file.
* Updated the robot launch command to use `spawn_robot.launch.py` and replaced the `namespace` argument with `robot_id` for consistency with the new launch file.