### PR TITLE
feat: Add Unity multi worlds

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,23 @@ Run:
 # 1 robot (default)
 ros2 launch unity_sim unity_complete.launch.py
 
+# 1 robot in simple_world
+ros2 launch unity_sim unity_complete.launch.py world:=simple_world
+
 # 3 robots and RViz on
 ros2 launch unity_sim unity_complete.launch.py robot_count:=3 run_rviz:=true
+
+# 2 robots, no RViz, in simple_world
+ros2 launch unity_sim unity_complete.launch.py robot_count:=2 run_rviz:=false world:=simple_world
+
 ```
 
 **Arguments**
 - `robot_count` (int, 1..5, default: 1) — spawns `robot`, `robot_2`, … `robot_5`.
 - `run_rviz` (bool, default: true) — toggles RViz2.
+- `world` (string, default: `empty_world`) — choose the world to load. Available worlds:
+  - `empty_world` — empty plane.
+  - `simple_world` — simple scene with some objects.
 
 > If the launch prints an error like
 > `Archive not found: .../unity_sim/worlds/unity_simulation.tar.gz`,

--- a/simulations/unity/unity_sim/worlds/.gitignore
+++ b/simulations/unity/unity_sim/worlds/.gitignore
@@ -1,0 +1,9 @@
+# Ignore all folder contents except the archive file
+*!unity_simulation.tar.gz
+*!unity_simulation_only.tar.gz
+# Ignore all extracted files and folders
+*
+# Keep this .gitignore file
+!.gitignore
+# Keep any README files
+!README.md


### PR DESCRIPTION
This pull request introduces support for selecting different simulation worlds when launching the Unity-based ROS2 simulation. It adds a new `world` argument to the launch file, updates the world extraction and execution logic, and improves documentation and file organization. The most important changes are grouped below:

**World selection and launch improvements:**

* Added a `world` argument to `unity_complete.launch.py`, allowing users to choose between `empty_world` and `simple_world` when launching the simulation. The launch file now passes the selected world archive to the simulation runner. [[1]](diffhunk://#diff-9adf9e44c17bbfeaf83607b0ca314c2ca18de8b2cab2db516d7fccbea9db6682R12-R14) [[2]](diffhunk://#diff-9adf9e44c17bbfeaf83607b0ca314c2ca18de8b2cab2db516d7fccbea9db6682L43-R76) [[3]](diffhunk://#diff-9adf9e44c17bbfeaf83607b0ca314c2ca18de8b2cab2db516d7fccbea9db6682L118-R145)
* Refactored the Unity simulation bootstrap logic to extract and run the correct world archive in its own subfolder, ensuring clean separation between different simulation environments.

**Documentation updates:**

* Updated `README.md` with new usage examples showing how to launch different worlds and combinations of robot counts and RViz settings. Also documented the new `world` argument and available options.

**File and repository organization:**

* Updated `.gitignore` in the `worlds` directory to ignore all extracted files and folders, except for the world archive files, `.gitignore`, and any README files.

These changes make it easier to manage and launch different simulation scenarios and keep the workspace clean.