### PR TITLE
feat: Add Unity launch configurations to benchmark simulator

### DIFF
--- a/benchmarks/unity/ros2_launch_timings_1758216494.csv
+++ b/benchmarks/unity/ros2_launch_timings_1758216494.csv
@@ -1,0 +1,2 @@
+simulator,timestamp,iteration,elapsed_seconds,cpu_mean_percent,ram_mean_mb,gpu_mean_percent,gpu_mem_mean_mb,real_time_factor_mean,iteration_total_time
+unity,2025-09-18T19:29:24.743402,1,8.039916515350342,22.259166666666665,1137.655078125,28.7,1364.5,0.9069009194256225,70.22501611709595

--- a/scripts/benchmark_simulator.py
+++ b/scripts/benchmark_simulator.py
@@ -66,6 +66,16 @@ LAUNCH_CONFIGS = {
         ],
         "NODES_TO_KILL": ["rviz2", "robot_state_publisher", "webots", "Ros2Supervisor", "static_transform_publisher"]
     },
+    "unity": {
+        "LAUNCH_SIMULATOR_CMD": [
+            "ros2", "launch", "unity_sim", "unity_complete.launch.py"
+        ],
+        "LAUNCH_ROBOT_CMD": [
+            "ros2", "launch", "robotnik_unity", "spawn_robot.launch.py",
+            "robot:=rbwatcher", "robot_id:=robot", "x:=2.0", "y:=2.0", "z:=0.0"
+        ],
+        "NODES_TO_KILL": ["rviz2", "ros_tcp_endpoint", "PI_simulation_Unity_Robotnik.x86_64"]
+    }
 }
 
 CATEGORY = [


### PR DESCRIPTION
This pull request adds support for the Unity simulator in the benchmark simulation script. The main change is the addition of a new configuration entry for Unity, specifying the commands to launch the simulator and robot, as well as the nodes to terminate.

Simulator support:

* Added a `"unity"` configuration to the simulator settings in `scripts/benchmark_simulator.py`, including launch commands for both the simulator and the robot, and a list of nodes to kill.