### PR TITLE
feat: add headless mode support for Unity simulation and update usage  instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ ros2 launch unity_sim unity_complete.launch.py robot_count:=3 run_rviz:=true
 # 2 robots, no RViz, in simple_world
 ros2 launch unity_sim unity_complete.launch.py robot_count:=2 run_rviz:=false world:=simple_world
 
+# Run Unity in headless mode (no UI, for benchmarks or servers)
+ros2 launch unity_sim unity_complete.launch.py headless:=true
+
+# Combine multiple arguments
+ros2 launch unity_sim unity_complete.launch.py headless:=true robot_count:=3 world:=simple_world
+
 ```
 
 **Arguments**
@@ -220,6 +226,7 @@ ros2 launch unity_sim unity_complete.launch.py robot_count:=2 run_rviz:=false wo
 - `world` (string, default: `empty_world`) — choose the world to load. Available worlds:
   - `empty_world` — empty plane.
   - `simple_world` — simple scene with some objects.
+- `headless` (bool, default: false) — runs Unity in batchmode (headless, no UI). Useful for benchmarks, automated testing, or running on servers without display.
 
 > If the launch prints an error like
 > `Archive not found: .../unity_sim/worlds/unity_simulation.tar.gz`,

--- a/simulations/unity/unity_sim/launch/unity_complete.launch.py
+++ b/simulations/unity/unity_sim/launch/unity_complete.launch.py
@@ -10,6 +10,7 @@
 #   run_rviz      (bool)  : launch RViz2 (default: true)
 #   robot_count   (int)   : number of robots to spawn [1..5] (default: 1)
 #   world         (str)   : name of the world to load (default: empty_world)
+#   headless      (bool)  : launch Unity in batchmode (default: false)
 
 import os
 from launch import LaunchDescription
@@ -50,8 +51,14 @@ def generate_launch_description():
         description="Name of the world to load"
     )
 
+    headless_arg = DeclareLaunchArgument(
+        "headless",
+        default_value="false",
+        description="Launch Unity in batchmode (headless, no UI)"
+    )
+
     # -------------------------
-    # OpaqueFunction para lanzar Unity con el mundo correcto
+    # OpaqueFunction to launch Unity with the correct world
     # -------------------------
     def launch_unity_with_world(context, *args, **kwargs):
         world_to_filename_map = {
@@ -61,15 +68,25 @@ def generate_launch_description():
         selected_world_name = LaunchConfiguration("world").perform(context)
         world_filename = world_to_filename_map[selected_world_name]
         
+        # Get headless value
+        headless_value = LaunchConfiguration("headless").perform(context).lower()
+        is_headless = headless_value in ["true", "1", "yes"]
+        
         print(f"[INFO] Selected world: '{selected_world_name}' -> using file: '{world_filename}'")
+        print(f"[INFO] Headless mode: {is_headless}")
 
         pkg_share_path = get_package_share_directory("unity_sim")
         autorun_script_path = os.path.join(
             pkg_share_path, "utils", "load_usd_and_run.py"
         )
         
+        # Build command with or without --batchmode
+        cmd = ["python3", autorun_script_path, world_filename]
+        if is_headless:
+            cmd.append("--batchmode")
+        
         unity_bootstrap = ExecuteProcess(
-            cmd=["python3", autorun_script_path, world_filename],
+            cmd=cmd,
             name="unity_sim_bootstrap",
             output="screen"
         )
@@ -103,7 +120,7 @@ def generate_launch_description():
     )
 
     # -------------------------
-    # Helper para generar las llamadas al servicio de spawn
+    # Helper to generate spawn service calls
     # -------------------------
     def build_spawn_calls(context, *args, **kwargs):
         try:
@@ -143,5 +160,6 @@ def generate_launch_description():
         run_rviz_arg,
         robot_count_arg,
         world_arg,
+        headless_arg,
         group,
     ])

--- a/simulations/unity/unity_sim/utils/load_usd_and_run.py
+++ b/simulations/unity/unity_sim/utils/load_usd_and_run.py
@@ -6,11 +6,13 @@
 #
 # Usage:
 #   python3 load_usd_and_run.py unity_simulation_only.tar.gz
-#   python3 load_usd_and_run.py unity_simulation.tar.gz
+#   python3 load_usd_and_run.py unity_simulation.tar.gz --batchmode
+#   python3 load_usd_and_run.py -b  # batchmode with default archive
 #
 # If no argument is given, it falls back to ARCHIVE_NAME.
 
 import sys
+import argparse
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -75,7 +77,7 @@ def ensure_extracted(worlds_dir: Path, archive_name: str, binary_name: str) -> P
 
     return sim_binary
 
-def main(archive_name: str, binary_name: str = BINARY_NAME):
+def main(archive_name: str, binary_name: str = BINARY_NAME, batchmode: bool = False):
     # Base path is the folder of this script
     script_dir = Path(__file__).resolve().parent
     worlds_dir = script_dir.parent / "worlds"
@@ -90,20 +92,57 @@ def main(archive_name: str, binary_name: str = BINARY_NAME):
     except Exception as e:
         print(f"[WARN] Could not change executable permissions: {e}")
 
+    # Unity CLI args
+    unity_args = [str(sim_binary)]
+    
+    # Add batchmode if requested
+    if batchmode:
+        unity_args.append("-batchmode")
+        unity_args.append("-logFile")
+        unity_args.append("-")
+        print("[INFO] Running in batchmode (headless)")
+    else:
+        print("[INFO] Running in normal mode (with UI)")
+    
+    # "-nographics",          # Enable this ONLY if you do not need camera rendering
+    # "-quit",               # Optional: auto-quit when done (usually not desired for sim servers)
+
+    print(f"[INFO] Starting Unity simulation: {' '.join(unity_args)}")
     # Run the simulation with its folder as CWD (keeps relative assets consistent)
-    print(f"[INFO] Starting Unity simulation: {sim_binary}")
     try:
-        subprocess.run([str(sim_binary)], cwd=sim_binary.parent, check=False)
+        subprocess.run(unity_args, cwd=sim_binary.parent, check=False)
     except Exception as e:
         print(f"[ERROR] Failed to start simulation: {e}")
         sys.exit(1)
 
 if __name__ == "__main__":
-    # Read the archive name from the first command-line argument (optional).
-    if len(sys.argv) >= 2 and sys.argv[1].strip():
-        archive_to_load = sys.argv[1]
-    else:
-        archive_to_load = ARCHIVE_NAME
-        print(f"[INFO] No archive name provided. Using default: {archive_to_load}")
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(
+        description="Load and run Unity simulation from a tar.gz archive.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 load_usd_and_run.py                           # Normal mode with default archive
+  python3 load_usd_and_run.py my_simulation.tar.gz      # Normal mode with specific archive
+  python3 load_usd_and_run.py my_simulation.tar.gz -b   # Batchmode with specific archive
+  python3 load_usd_and_run.py --batchmode               # Batchmode with default archive
+        """
+    )
+    parser.add_argument(
+        "archive",
+        nargs="?",
+        default=ARCHIVE_NAME,
+        help=f"Path to the Unity simulation tar.gz archive (default: {ARCHIVE_NAME})"
+    )
+    parser.add_argument(
+        "-b", "--batchmode",
+        action="store_true",
+        help="Run Unity in batchmode (headless, no UI)"
+    )
+    
+    args = parser.parse_args()
+    
+    if args.archive == ARCHIVE_NAME and len(sys.argv) == 1:
+        print(f"[INFO] No archive name provided. Using default: {args.archive}")
 
-    main(archive_name=archive_to_load)
+    main(archive_name=args.archive, batchmode=args.batchmode)


### PR DESCRIPTION
This pull request adds support for running the Unity simulator in headless (batch) mode, making it suitable for benchmarks, automated testing, or running on servers without a display. The changes introduce a new `headless` launch argument, update the launch pipeline to handle this argument, and enhance the Unity runner script to accept a `--batchmode` flag. Documentation is updated to reflect these new capabilities.

**Launch system enhancements:**

* Added a `headless` (bool) argument to `unity_complete.launch.py` that allows users to run Unity in batchmode (headless, no UI), with corresponding updates to argument parsing and command construction. [[1]](diffhunk://#diff-9adf9e44c17bbfeaf83607b0ca314c2ca18de8b2cab2db516d7fccbea9db6682R13) [[2]](diffhunk://#diff-9adf9e44c17bbfeaf83607b0ca314c2ca18de8b2cab2db516d7fccbea9db6682R54-R61) [[3]](diffhunk://#diff-9adf9e44c17bbfeaf83607b0ca314c2ca18de8b2cab2db516d7fccbea9db6682R71-R89) [[4]](diffhunk://#diff-9adf9e44c17bbfeaf83607b0ca314c2ca18de8b2cab2db516d7fccbea9db6682R163)
* Updated the Unity runner script `load_usd_and_run.py` to accept a `--batchmode`/`-b` flag, which runs Unity with the appropriate CLI arguments for headless operation. [[1]](diffhunk://#diff-6668d8c25b69dee06e825ea7f47583a3f3e2a22ca8ec02c5bf0caab9c126e539L9-R15) [[2]](diffhunk://#diff-6668d8c25b69dee06e825ea7f47583a3f3e2a22ca8ec02c5bf0caab9c126e539L78-R80) [[3]](diffhunk://#diff-6668d8c25b69dee06e825ea7f47583a3f3e2a22ca8ec02c5bf0caab9c126e539R95-R148)

**Documentation updates:**

* Extended the `README.md` with usage examples for headless mode, including how to combine arguments and an explanation of the new `headless` option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R215-R220) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R229)